### PR TITLE
Clarify test folders in docs

### DIFF
--- a/csv_to_dxf-master/README.md
+++ b/csv_to_dxf-master/README.md
@@ -30,11 +30,19 @@ CSVファイルから道路断面図のDXFファイルを生成するツール�
 
 ### 自動テスト
 
-テストスクリプトを使用して、CSVからDXFへの変換フローを自動テストできます。
+このリポジトリには二種類のテストが含まれています。
+
+- `test/` ディレクトリ: `unittest` を用いたユニットテスト
+- `tests/` ディレクトリ: `pytest` を用いた追加テスト
+
+すべてのテストを実行するには以下のコマンドを使用します。
 
 ```bash
-# テストを実行
-python tests/test_save_dxf.py
+# unittest ベースのテスト
+python -m unittest discover -s test
+
+# pytest ベースのテスト
+pytest tests
 ```
 
 テストは以下のフローをカバーしています：

--- a/csv_to_dxf-master/README_en.md
+++ b/csv_to_dxf-master/README_en.md
@@ -162,17 +162,19 @@ This file can be opened with the following software:
 
 ## Running Tests
 
-To run the automated tests, use the following commands:
+The repository contains two sets of tests:
+
+- `test/` &ndash; unit tests that use Python's built in `unittest`
+- `tests/` &ndash; additional tests executed with `pytest`
+
+To run all available tests, execute the following commands:
 
 ```bash
-# Run all tests
+# Run the unittest based tests
 python -m unittest discover -s test
 
-# Run individual tests
-python -m unittest test.test_loader
-python -m unittest test.test_table_to_dxf
-python -m unittest test.test_dxf_draw_tenkaiz
-python -m unittest test.test_dxf_draw_tenkaiz_one_side  # Tests for one-sided width
+# Run the pytest based tests
+pytest tests
 ```
 
 ## Common Errors and Solutions


### PR DESCRIPTION
## Summary
- document both `test/` and `tests/` directories
- show how to run unittest and pytest suites

## Testing
- `python -m unittest discover -s test` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests` *(fails: multiple collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fdfd40e208320a54678a8b65d5196