### PR TITLE
Fix typos in tenkaiz drawing helpers

### DIFF
--- a/csv_to_dxf-master/src/dxf_draw_tenkaiz.py
+++ b/csv_to_dxf-master/src/dxf_draw_tenkaiz.py
@@ -67,8 +67,8 @@ def draw_road_sections(modelspace, data, scale=1000.0, text_height=350.0):
         
         linelr = ((x_scaled, wl_scaled), (x_scaled, 0), (x_scaled, -wr_scaled))
 
-        line_conditions = coodinate_lines(row, prev_linelr, scale)
-        dim_conditions, underline_conditions = coodinate_dimensions(row, prev_linelr, scale, text_height)
+        line_conditions = coordinate_lines(row, prev_linelr, scale)
+        dim_conditions, underline_conditions = coordinate_dimensions(row, prev_linelr, scale, text_height)
 
         draw_with(modelspace, line_conditions, draw_line)
         draw_with(modelspace, dim_conditions, draw_dim)
@@ -76,7 +76,7 @@ def draw_road_sections(modelspace, data, scale=1000.0, text_height=350.0):
 
         prev_linelr = linelr
 
-def coodinate_lines(row, prev_linelr, scale=1000.0):
+def coordinate_lines(row, prev_linelr, scale=1000.0):
     """線の描画条件を計算する
     
     Args:
@@ -104,7 +104,7 @@ def coodinate_lines(row, prev_linelr, scale=1000.0):
     ]
     return conditions
 
-def coodinate_dimensions(row, prev_points, scale=1000.0, text_height=350.0):
+def coordinate_dimensions(row, prev_points, scale=1000.0, text_height=350.0):
     """寸法の描画条件を計算する
     
     Args:

--- a/csv_to_dxf-master/test/test_csv_to_dxf.py
+++ b/csv_to_dxf-master/test/test_csv_to_dxf.py
@@ -175,13 +175,13 @@ def manual_convert_csv_to_dxf(csv_file, output_dxf, scale=1000.0, text_height=35
         return False
 
 
-# coodinate_dimensions関数のインターフェースを確認する関数
-def inspect_coodinate_dimensions():
-    """coodinate_dimensions関数のインターフェースを検査"""
-    print("\ncoodinate_dimensions関数の詳細:")
-    sig = inspect.signature(dxf_draw_tenkaiz.coodinate_dimensions)
+# coordinate_dimensions関数のインターフェースを確認する関数
+def inspect_coordinate_dimensions():
+    """coordinate_dimensions関数のインターフェースを検査"""
+    print("\ncoordinate_dimensions関数の詳細:")
+    sig = inspect.signature(dxf_draw_tenkaiz.coordinate_dimensions)
     print(f"関数シグネチャ: {sig}")
-    print(f"ドキュメント: {dxf_draw_tenkaiz.coodinate_dimensions.__doc__}")
+    print(f"ドキュメント: {dxf_draw_tenkaiz.coordinate_dimensions.__doc__}")
     
     # 関数の引数名とデフォルト値を表示
     for param_name, param in sig.parameters.items():
@@ -301,7 +301,7 @@ if __name__ == "__main__":
     # デバッグモードの場合、モジュール内の関数を確認
     if debug:
         inspect_module_functions()
-        inspect_coodinate_dimensions()
+        inspect_coordinate_dimensions()
     
     dxf_file_path = None  # 生成されたDXFファイルのパスを格納
     

--- a/csv_to_dxf-master/test/test_distance_handling.py
+++ b/csv_to_dxf-master/test/test_distance_handling.py
@@ -73,17 +73,17 @@ class TestDistanceHandling(unittest.TestCase):
         print(f"追加延長ファイルが生成されました: {self.test_tsuikaenkyo_file}")
         print("\n※注: dxf_draw_tenkaiz.pyではx座標に直接この値を使用するため、単延長の場合はレイアウトが異なります")
         
-        # dxf_draw_tenkaiz.pyのcoodinate_dimensions関数の処理を確認
+        # dxf_draw_tenkaiz.pyのcoordinate_dimensions関数の処理を確認
         print("\n=============== 距離計算の処理 ===============")
         row_tanenkyo = tanenkyo_data.iloc[1]  # No.1のデータ
         prev_points = ((0.0, 3.0), (0.0, 0.0), (0.0, -3.0))  # No.0の座標
         
         # 単延長の場合の寸法計算
-        result_tanenkyo = dxf_draw_tenkaiz.coodinate_dimensions(row_tanenkyo, prev_points)
+        result_tanenkyo = dxf_draw_tenkaiz.coordinate_dimensions(row_tanenkyo, prev_points)
         
         # 追加延長の場合の寸法計算
         row_tsuikaenkyo = tsuikaenkyo_data.iloc[1]  # No.1のデータ
-        result_tsuikaenkyo = dxf_draw_tenkaiz.coodinate_dimensions(row_tsuikaenkyo, prev_points)
+        result_tsuikaenkyo = dxf_draw_tenkaiz.coordinate_dimensions(row_tsuikaenkyo, prev_points)
         
         # 結果を表示
         print("\n== 単延長の場合の処理 ==")

--- a/csv_to_dxf-master/test/test_dxf_draw_tenkaiz.py
+++ b/csv_to_dxf-master/test/test_dxf_draw_tenkaiz.py
@@ -44,7 +44,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
         self.assertGreater(len(lines), 0)
         self.assertGreater(len(texts), 0)
     
-    def test_coodinate_lines(self):
+    def test_coordinate_lines(self):
         # 行データ - DataFrameのSeriesオブジェクトとして作成
         row = pd.Series({
             'name': 'No.1',
@@ -55,7 +55,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
         prev_linelr = ((0.0, 3.45), (0.0, 0), (0.0, -3.55))  # No.0のデータから計算される座標
         
         # 座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_lines(row, prev_linelr)
+        result = dxf_draw_tenkaiz.coordinate_lines(row, prev_linelr)
         
         # 結果は5つの条件と座標のタプルのリストであることを確認
         self.assertEqual(len(result), 5)
@@ -68,7 +68,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
             for point in points:
                 self.assertEqual(len(point), 2)
     
-    def test_coodinate_dimensions(self):
+    def test_coordinate_dimensions(self):
         # 行データ - DataFrameのSeriesオブジェクトとして作成
         row = pd.Series({
             'name': 'No.1',
@@ -79,7 +79,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
         prev_points = ((0.0, 3.45), (0.0, 0), (0.0, -3.55))  # No.0のデータから計算される座標
         
         # 寸法座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_dimensions(row, prev_points)
+        result = dxf_draw_tenkaiz.coordinate_dimensions(row, prev_points)
         
         # 結果は4つの条件と寸法情報のタプルのリストであることを確認
         self.assertEqual(len(result), 4)

--- a/csv_to_dxf-master/test/test_dxf_draw_tenkaiz_one_side.py
+++ b/csv_to_dxf-master/test/test_dxf_draw_tenkaiz_one_side.py
@@ -94,7 +94,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         doc_right.saveas(self.test_dxf_path_right)
         self.assertTrue(os.path.exists(self.test_dxf_path_right))
     
-    def test_coodinate_dimensions_left_only(self):
+    def test_coordinate_dimensions_left_only(self):
         # 左側幅員のみの行データ
         row = pd.Series({
             'name': 'No.1',
@@ -105,7 +105,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         prev_points = ((0.0, 3.45), (0.0, 0), (0.0, 0.0))  # 前のポイント（右側幅員0）
         
         # 寸法座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_dimensions(row, prev_points)
+        result = dxf_draw_tenkaiz.coordinate_dimensions(row, prev_points)
         
         # 結果をチェック
         # 左側幅員の寸法が含まれていることを確認
@@ -116,7 +116,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         right_width_dimensions = [dim for cond, dim in result if cond and dim[0] == "0.00"]
         self.assertEqual(len(right_width_dimensions), 0)
     
-    def test_coodinate_dimensions_right_only(self):
+    def test_coordinate_dimensions_right_only(self):
         # 右側幅員のみの行データ
         row = pd.Series({
             'name': 'No.1',
@@ -127,7 +127,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         prev_points = ((0.0, 0.0), (0.0, 0), (0.0, -3.55))  # 前のポイント（左側幅員0）
         
         # 寸法座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_dimensions(row, prev_points)
+        result = dxf_draw_tenkaiz.coordinate_dimensions(row, prev_points)
         
         # 結果をチェック
         # 左側幅員の寸法が含まれていないことを確認（wl=0.0のため）

--- a/csv_to_dxf-master/tests/e2e/test_csv_to_dxf.py
+++ b/csv_to_dxf-master/tests/e2e/test_csv_to_dxf.py
@@ -252,13 +252,13 @@ def manual_convert_csv_to_dxf(csv_file, output_dxf, scale=1000.0, text_height=35
         return False
 
 
-# coodinate_dimensions関数のインターフェースを確認する関数
-def inspect_coodinate_dimensions():
-    """coodinate_dimensions関数のインターフェースを検査"""
-    print("\ncoodinate_dimensions関数の詳細:")
-    sig = inspect.signature(dxf_draw_tenkaiz.coodinate_dimensions)
+# coordinate_dimensions関数のインターフェースを確認する関数
+def inspect_coordinate_dimensions():
+    """coordinate_dimensions関数のインターフェースを検査"""
+    print("\ncoordinate_dimensions関数の詳細:")
+    sig = inspect.signature(dxf_draw_tenkaiz.coordinate_dimensions)
     print(f"関数シグネチャ: {sig}")
-    print(f"ドキュメント: {dxf_draw_tenkaiz.coodinate_dimensions.__doc__}")
+    print(f"ドキュメント: {dxf_draw_tenkaiz.coordinate_dimensions.__doc__}")
     
     # 関数の引数名とデフォルト値を表示
     for param_name, param in sig.parameters.items():
@@ -378,7 +378,7 @@ if __name__ == "__main__":
     # デバッグモードの場合、モジュール内の関数を確認
     if debug:
         inspect_module_functions()
-        inspect_coodinate_dimensions()
+        inspect_coordinate_dimensions()
     
     dxf_file_path = None  # 生成されたDXFファイルのパスを格納
     

--- a/csv_to_dxf-master/tests/integration/test_distance_handling.py
+++ b/csv_to_dxf-master/tests/integration/test_distance_handling.py
@@ -110,17 +110,17 @@ class TestDistanceHandling(unittest.TestCase):
         print(f"追加延長ファイルが生成されました: {self.test_tsuikaenkyo_file}")
         print("\n※注: dxf_draw_tenkaiz.pyではx座標に直接この値を使用するため、単延長の場合はレイアウトが異なります")
         
-        # dxf_draw_tenkaiz.pyのcoodinate_dimensions関数の処理を確認
+        # dxf_draw_tenkaiz.pyのcoordinate_dimensions関数の処理を確認
         print("\n=============== 距離計算の処理 ===============")
         row_tanenkyo = tanenkyo_data.iloc[1]  # No.1のデータ
         prev_points = ((0.0, 3.0), (0.0, 0.0), (0.0, -3.0))  # No.0の座標
         
         # 単延長の場合の寸法計算
-        result_tanenkyo = dxf_draw_tenkaiz.coodinate_dimensions(row_tanenkyo, prev_points)
+        result_tanenkyo = dxf_draw_tenkaiz.coordinate_dimensions(row_tanenkyo, prev_points)
         
         # 追加延長の場合の寸法計算
         row_tsuikaenkyo = tsuikaenkyo_data.iloc[1]  # No.1のデータ
-        result_tsuikaenkyo = dxf_draw_tenkaiz.coodinate_dimensions(row_tsuikaenkyo, prev_points)
+        result_tsuikaenkyo = dxf_draw_tenkaiz.coordinate_dimensions(row_tsuikaenkyo, prev_points)
         
         # 結果を表示
         print("\n== 単延長の場合の処理 ==")

--- a/csv_to_dxf-master/tests/unit/test_dxf_draw_tenkaiz.py
+++ b/csv_to_dxf-master/tests/unit/test_dxf_draw_tenkaiz.py
@@ -74,7 +74,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
         self.assertGreater(len(lines), 0)
         self.assertGreater(len(texts), 0)
     
-    def test_coodinate_lines(self):
+    def test_coordinate_lines(self):
         # 行データ - DataFrameのSeriesオブジェクトとして作成
         row = pd.Series({
             'name': 'No.1',
@@ -85,7 +85,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
         prev_linelr = ((0.0, 3.45), (0.0, 0), (0.0, -3.55))  # No.0のデータから計算される座標
         
         # 座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_lines(row, prev_linelr)
+        result = dxf_draw_tenkaiz.coordinate_lines(row, prev_linelr)
         
         # 結果は5つの条件と座標のタプルのリストであることを確認
         self.assertEqual(len(result), 5)
@@ -98,7 +98,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
             for point in points:
                 self.assertEqual(len(point), 2)
     
-    def test_coodinate_dimensions(self):
+    def test_coordinate_dimensions(self):
         # 行データ - DataFrameのSeriesオブジェクトとして作成
         row = pd.Series({
             'name': 'No.1',
@@ -109,7 +109,7 @@ class TestDxfDrawTenkaiz(unittest.TestCase):
         prev_points = ((0.0, 3.45), (0.0, 0), (0.0, -3.55))  # No.0のデータから計算される座標
         
         # 寸法座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_dimensions(row, prev_points)
+        result = dxf_draw_tenkaiz.coordinate_dimensions(row, prev_points)
         
         # 結果は4つの条件と寸法情報のタプルのリストであることを確認
         self.assertEqual(len(result), 4)

--- a/csv_to_dxf-master/tests/unit/test_dxf_draw_tenkaiz_one_side.py
+++ b/csv_to_dxf-master/tests/unit/test_dxf_draw_tenkaiz_one_side.py
@@ -123,7 +123,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         doc_right.saveas(self.test_dxf_path_right)
         self.assertTrue(os.path.exists(self.test_dxf_path_right))
     
-    def test_coodinate_dimensions_left_only(self):
+    def test_coordinate_dimensions_left_only(self):
         # 左側幅員のみの行データ
         row = pd.Series({
             'name': 'No.1',
@@ -134,7 +134,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         prev_points = ((0.0, 3.45), (0.0, 0), (0.0, 0.0))  # 前のポイント（右側幅員0）
         
         # 寸法座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_dimensions(row, prev_points)
+        result = dxf_draw_tenkaiz.coordinate_dimensions(row, prev_points)
         
         # 結果をチェック
         # 左側幅員の寸法が含まれていることを確認
@@ -145,7 +145,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         right_width_dimensions = [dim for cond, dim in result if cond and dim[0] == "0.00"]
         self.assertEqual(len(right_width_dimensions), 0)
     
-    def test_coodinate_dimensions_right_only(self):
+    def test_coordinate_dimensions_right_only(self):
         # 右側幅員のみの行データ
         row = pd.Series({
             'name': 'No.1',
@@ -156,7 +156,7 @@ class TestDxfDrawTenkaizOneSide(unittest.TestCase):
         prev_points = ((0.0, 0.0), (0.0, 0), (0.0, -3.55))  # 前のポイント（左側幅員0）
         
         # 寸法座標計算をテスト
-        result = dxf_draw_tenkaiz.coodinate_dimensions(row, prev_points)
+        result = dxf_draw_tenkaiz.coordinate_dimensions(row, prev_points)
         
         # 結果をチェック
         # 左側幅員の寸法が含まれていないことを確認（wl=0.0のため）


### PR DESCRIPTION
## Summary
- rename `coodinate_lines` and `coodinate_dimensions` to `coordinate_lines` and `coordinate_dimensions`
- update internal calls and tests

## Testing
- `pytest -q` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683fdfd0fa008320b173e5c7ca4b3016