### PR TITLE
Apply 2x vertical scale to cross-section drawings

### DIFF
--- a/cross-section-ui/src/lib.rs
+++ b/cross-section-ui/src/lib.rs
@@ -243,8 +243,9 @@ pub fn generate_drawing(section: &CrossSectionData) -> Drawing {
     let to_dxf_x = |cumulative_distance: f64| -> f64 {
         (cumulative_distance - cl_offset) * scale  // CLが原点に来るようにオフセット
     };
+    let y_scale = scale * 2.0;  // 縦方向スケールを2倍（縦断図と同様）
     let to_dxf_y = |height: f64| -> f64 {
-        (height - dl) * scale
+        (height - dl) * y_scale
     };
 
     let l_data = &data[0];
@@ -465,7 +466,7 @@ pub fn generate_multi_drawing(sections: &[CrossSectionData], columns: usize, col
         cumulative_x += cell_width;
     }
 
-    let cell_height = (max_height + 3.0) * scale;  // 旗揚げ部分のマージン
+    let cell_height = (max_height + 3.0) * scale * 2.0;  // 旗揚げ部分のマージン（縦スケール2倍）
 
     // セクションを描画
     for (idx, section) in sections.iter().enumerate() {
@@ -486,7 +487,8 @@ fn draw_section_at_offset(drawing: &mut Drawing, section: &CrossSectionData,
     let data = &section.survey_data;
     let dl = round_dl(section.dl);
     let to_dxf_x = |d: f64| offset_x + d * scale;
-    let to_dxf_y = |h: f64| offset_y + (h - dl) * scale;
+    let y_scale = scale * 2.0;  // 縦方向スケールを2倍（縦断図と同様）
+    let to_dxf_y = |h: f64| offset_y + (h - dl) * y_scale;
 
     let l_data = &data[0];
     let cl_data = &data[section.cl_index.min(data.len() - 1)];


### PR DESCRIPTION
## Summary
This PR applies a 2x vertical scale factor to cross-section drawings to match the vertical scale used in longitudinal profile drawings (縦断図).

## Changes
- **`generate_drawing()`**: Introduced `y_scale` variable set to `scale * 2.0` and applied it to the `to_dxf_y` coordinate transformation function
- **`generate_multi_drawing()`**: Updated `cell_height` calculation to include the 2x vertical scale factor for proper spacing in multi-section layouts
- **`draw_section_at_offset()`**: Added `y_scale` variable and applied it to the `to_dxf_y` coordinate transformation function for individual section rendering

## Implementation Details
- The vertical scale is consistently applied as `scale * 2.0` across all three functions that handle drawing generation
- The horizontal scale remains unchanged; only the vertical (height) dimension is affected
- This ensures visual consistency between cross-section and longitudinal profile drawings
- Comments in Japanese (縦方向スケールを2倍) indicate this aligns with existing longitudinal drawing conventions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns cross-section visuals with longitudinal profile scaling by doubling vertical scale.
> 
> - Apply `y_scale = scale * 2.0` to `to_dxf_y` in `generate_drawing()` and `draw_section_at_offset()`
> - Update `generate_multi_drawing()` to use `cell_height = (max_height + 3.0) * scale * 2.0` for proper grid spacing
> - Horizontal scaling and data calculations remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1eddf04960a135805f36dbefac24a58700c94cc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->