### PR TITLE
Replace section index logic with route start/end flags

### DIFF
--- a/cross-section-ui/src/lib.rs
+++ b/cross-section-ui/src/lib.rs
@@ -961,7 +961,6 @@ fn generate_multi_drawing_internal(
     };
 
     // セクションを描画
-    let section_count = sections.len();
     for (idx, section) in sections.iter().enumerate() {
         if section.survey_data.len() < 2 { continue; }
         let col = idx / rows_per_column;
@@ -983,7 +982,7 @@ fn generate_multi_drawing_internal(
         let offset_y = row_in_col as f64 * cell_height + col_y_offset;
 
         // 中間測点（起終点以外）の場合のみ、補完点を勾配補間
-        let is_start_or_end = idx == 0 || idx == section_count - 1;
+        let is_start_or_end = section.is_route_start || section.is_route_end;
         if interpolate_intermediate && !is_start_or_end {
             let mut section_to_draw = section.clone();
             section_to_draw.interpolate_planned_heights();
@@ -1105,8 +1104,6 @@ fn generate_all_pages_drawing_internal(
     const PAGE_GAP_MM: f64 = 10.0;
     let page_gap_dxf = PAGE_GAP_MM * frame_scale;
 
-    let total_section_count = all_sections.len();
-
     // 各ページを描画
     for page in 0..total_pages {
         let start_idx = page * sections_per_page;
@@ -1129,7 +1126,7 @@ fn generate_all_pages_drawing_internal(
         // このページのセクションを描画
         draw_page_content(
             &mut drawing, page_sections, columns, column_gap, row_gap, frame_scale, &info, page_offset_y,
-            start_idx, total_section_count, interpolate_intermediate
+            interpolate_intermediate
         );
     }
 
@@ -1137,9 +1134,7 @@ fn generate_all_pages_drawing_internal(
 }
 
 /// 1ページ分のコンテンツを描画（オフセット付き）
-/// global_start_idx: このページの最初のセクションの全体でのインデックス
-/// total_section_count: 全ページを通じた総セクション数
-/// interpolate_intermediate: 中間測点の補完点を勾配補間するか
+/// interpolate_intermediate: 中間測点の補完点を勾配補間するか（起終点はフラグで判定）
 fn draw_page_content(
     drawing: &mut Drawing,
     sections: &[CrossSectionData],
@@ -1149,8 +1144,6 @@ fn draw_page_content(
     frame_scale: f64,
     title_info: &TitleBlockInfo,
     page_offset_y: f64,
-    global_start_idx: usize,
-    total_section_count: usize,
     interpolate_intermediate: bool,
 ) {
     use available_area as area;
@@ -1209,8 +1202,7 @@ fn draw_page_content(
         let offset_y = row_in_col as f64 * cell_height + col_y_offset + page_offset_y;
 
         // 中間測点（起終点以外）の場合のみ、補完点を勾配補間
-        let global_idx = global_start_idx + idx;
-        let is_start_or_end = global_idx == 0 || global_idx == total_section_count - 1;
+        let is_start_or_end = section.is_route_start || section.is_route_end;
         if interpolate_intermediate && !is_start_or_end {
             let mut section_to_draw = section.clone();
             section_to_draw.interpolate_planned_heights();
@@ -2579,6 +2571,12 @@ pub struct CrossSectionData {
     /// ルートID（route_1, route_2など）
     #[serde(default = "default_route_id")]
     pub route_id: String,
+    /// 路線の起点かどうか（補間しない）
+    #[serde(default)]
+    pub is_route_start: bool,
+    /// 路線の終点かどうか（補間しない）
+    #[serde(default)]
+    pub is_route_end: bool,
 }
 
 fn default_route_id() -> String {
@@ -2624,6 +2622,8 @@ impl CrossSectionData {
             dl, cl_index, l_to_cl_distance: l_to_cl, survey_data,
             route_distance: None, // 測点名からパースされる
             route_id: default_route_id(),
+            is_route_start: false,
+            is_route_end: false,
         }
     }
 
@@ -2763,6 +2763,8 @@ impl CrossSectionData {
             survey_data,
             route_distance: None,
             route_id: default_route_id(),
+            is_route_start: false,
+            is_route_end: false,
         })
     }
 }
@@ -3590,10 +3592,9 @@ impl eframe::App for CrossSectionApp {
                                     if let Some(idx) = self.selected_index {
                                         if let Some(section) = filtered_for_dxf.get(idx) {
                                             // 起終点以外は補間を適用
-                                            let is_first = idx == 0;
-                                            let is_last = idx == filtered_for_dxf.len() - 1;
+                                            let is_start_or_end = section.is_route_start || section.is_route_end;
                                             let mut section = section.clone();
-                                            if !is_first && !is_last {
+                                            if !is_start_or_end {
                                                 section.interpolate_planned_heights();
                                             }
                                             let dxf_content = generate_dxf_bytes(&section);
@@ -3854,10 +3855,9 @@ impl eframe::App for CrossSectionApp {
                             if let Some(section) = filtered_for_download.get(idx) {
                                 if ui.button("Download DXF").clicked() {
                                     // 起終点以外は補間を適用
-                                    let is_first = idx == 0;
-                                    let is_last = idx == filtered_for_download.len() - 1;
+                                    let is_start_or_end = section.is_route_start || section.is_route_end;
                                     let mut section = section.clone();
-                                    if !is_first && !is_last {
+                                    if !is_start_or_end {
                                         section.interpolate_planned_heights();
                                     }
                                     let dxf_content = generate_dxf_bytes(&section);

--- a/src/xlsx_parser.py
+++ b/src/xlsx_parser.py
@@ -41,6 +41,8 @@ class CrossSectionData:
     survey_data: list[SurveyRow]  # 測量データ
     route_distance: Optional[float] = None  # 路線距離（m）
     route_id: str = "route_1"     # ルートID
+    is_route_start: bool = False  # 路線の起点かどうか（補間しない）
+    is_route_end: bool = False    # 路線の終点かどうか（補間しない）
 
 
 @dataclass
@@ -592,7 +594,22 @@ def to_cross_section_ui_format(data: dict) -> list[dict]:
             "survey_data": s["survey_data"],
             "route_distance": s["route_distance"],
             "route_id": s.get("route_id", "route_1"),
+            "is_route_start": False,
+            "is_route_end": False,
         })
+
+    # 各ルートごとに起終点フラグを設定
+    route_indices: dict[str, list[int]] = {}
+    for i, s in enumerate(sections):
+        route_id = s["route_id"]
+        if route_id not in route_indices:
+            route_indices[route_id] = []
+        route_indices[route_id].append(i)
+
+    for indices in route_indices.values():
+        if indices:
+            sections[indices[0]]["is_route_start"] = True
+            sections[indices[-1]]["is_route_end"] = True
 
     return sections
 


### PR DESCRIPTION
## Summary
Refactored the cross-section interpolation logic to use explicit `is_route_start` and `is_route_end` flags instead of relying on array indices. This makes the code more maintainable and allows proper handling of sections that may be filtered or reordered.

## Key Changes
- Added `is_route_start` and `is_route_end` boolean fields to `CrossSectionData` struct
- Removed dependency on `section_count` and `global_start_idx` variables in drawing functions
- Updated `generate_multi_drawing_internal()` to check flags instead of comparing indices
- Simplified `draw_page_content()` by removing `global_start_idx` and `total_section_count` parameters
- Updated Python parser to set route start/end flags based on route grouping
- Applied interpolation logic consistently in DXF export handlers

## Implementation Details
- The flags are serialized/deserialized with `#[serde(default)]` for backward compatibility
- Route grouping in the Python parser identifies start/end sections per route ID
- DXF export now applies the same interpolation rules as multi-drawing generation
- All section initialization methods properly set the new flags to `false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors interpolation control to be flag-driven, improving stability when sections are filtered/reordered.
> 
> - Add `is_route_start`/`is_route_end` to `CrossSectionData` (serde defaults; initialized to `false` in all constructors)
> - Replace index comparisons with flag checks in multi-page/grid rendering and `draw_page_content`; remove `global_start_idx`/`total_section_count` params
> - Apply interpolated drawing variants broadly (e.g., `Single`, `AllGrid` with/without frame) and align DXF export to interpolate except at start/end sections
> - Python `xlsx_parser`: extend dataclass and JSON output with flags; set start/end per `route_id` grouping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b4795ea77e075dfbedddd9c62f8a18f722ab6c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->